### PR TITLE
Use the libvirt API to obtain DHCP leases.

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -1,4 +1,4 @@
 default: build
 
 build:
-	GOGC=off go build -i -o docker-machine-driver-kvm
+	GOGC=off go build -tags libvirt.1.2.14 -i -o docker-machine-driver-kvm


### PR DESCRIPTION
Requires libvirt >= 1.2.6. The tag libvirt.1.2.14 is required by
libvirt-go to enable its use, since a wider range of libvirt versions
are supported there.
